### PR TITLE
Make standalone publishing conditional

### DIFF
--- a/jenkins/pipelines/releng/promote-a-build.Jenkinsfile
+++ b/jenkins/pipelines/releng/promote-a-build.Jenkinsfile
@@ -45,6 +45,7 @@ spec:
   parameters {
     booleanParam(defaultValue: true, description: 'Do a dry run of the build. All commands will be echoed.First run with this on, then when you are sure it is right, choose rebuild in the passing job and uncheck this box', name: 'DRY_RUN')
     choice(choices: ['cdt', 'tools.templates', 'launchbar'], description: 'Project to promote. Promoting cdt will include the cdt standalone debugger.', name: 'PROJECT')
+    booleanParam(defaultValue: true, description: 'Include CDT standalone debugger when publishing (if applicable)', name: 'STANDALONE')
     string(defaultValue: '9.8', description: 'The major and minor version of CDT being released (e.g. 9.7, 9.8, 10.0).', name: 'MINOR_VERSION')
     string(defaultValue: 'cdt-9.8.0', description: 'The full name of this release (e.g. cdt-9.4.2, cdt-9.5.0-rc1, cdt-9.5.0-photon-m7, cdt-9.5.0-photon-rc1)', name: 'MILESTONE')
     string(defaultValue: 'cdt-master', description: 'The CI job name being promoted from', name: 'CDT_JOB_NAME')

--- a/scripts/promote-a-build.sh
+++ b/scripts/promote-a-build.sh
@@ -49,7 +49,7 @@ $ECHO $SSH "cd $DOWNLOAD && \
     mv org.eclipse.$PROJECT.repo.zip $MILESTONE.zip"
 
 # promote standalone debugger
-if [ "$PROJECT" == "cdt" ]; then
+if [ "$PROJECT" == "cdt" ] && [ "$STANDALONE" == "true" ]; then
     $ECHO $SSH "mkdir -p $DOWNLOAD/rcp"
 
     $ECHO $SSH "cd $DOWNLOAD/rcp && \


### PR DESCRIPTION
This allows us to publish just CDT without standalone debugger to
handle platform rebuilds properly.