### PR TITLE
Sdk updates

### DIFF
--- a/docker/cdt-infra-platform-sdk/sdk4.9-ubuntu-18.04/Dockerfile
+++ b/docker/cdt-infra-platform-sdk/sdk4.9-ubuntu-18.04/Dockerfile
@@ -1,11 +1,14 @@
-FROM cdt-infra-base:ubuntu-18.04
+FROM cdt-infra-eclipse-full:ubuntu-18.04
 
 USER root
 #Eclipse SDK
-ENV ECLIPSE_VERSION 4.9
 RUN mkdir -p ${HOME}/buildtools && cd ${HOME}/buildtools \
   && curl -sL https://download.eclipse.org/eclipse/downloads/drops4/R-4.9-201809060745/eclipse-SDK-4.9-linux-gtk-x86_64.tar.gz | tar xvz \
-  && mv eclipse eclipse-SDK-${ECLIPSE_VERSION}
+  && mv eclipse eclipse-SDK-4.9
+
+RUN mkdir -p ${HOME}/buildtools && cd ${HOME}/buildtools \
+  && curl -sL https://download.eclipse.org/eclipse/downloads/drops4/R-4.13-201909161045/eclipse-SDK-4.13-linux-gtk-x86_64.tar.gz | tar xvz \
+  && mv eclipse eclipse-SDK-4.13
 
 #Fix permissions for OpenShift & standard k8s
 RUN chown -R 1000:0 ${HOME} \

--- a/jenkins/pod-templates/cdt-platform-sdk.yaml
+++ b/jenkins/pod-templates/cdt-platform-sdk.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: platform-sdk
-    image: quay.io/eclipse-cdt/cdt-infra-platform-sdk@sha256:0695a736d5cad0b1ae55263ab79ce27d40ed519800f1ab9c77bdc40040ab8494
+    image: quay.io/eclipse-cdt/cdt-infra-platform-sdk@sha256:664154af0b9b972c91009f1aa5597f2c7d4ea6589a93ef38a6bb2d6c21df73b0
     tty: true
     command: ["/bin/sh"]
     args: ["-c", "cat"]


### PR DESCRIPTION
Use full CDT in SDK image & add SDK 4.13 as an option 

This allows us to run maven and cross compiles to check natives are
up to date