### PR TITLE
Added dumb-init to Docker entrypoint to rip zombie processes

### DIFF
--- a/docker/cdt-infra-base/ubuntu-18.04/Dockerfile
+++ b/docker/cdt-infra-base/ubuntu-18.04/Dockerfile
@@ -8,10 +8,11 @@ COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint
 RUN chmod u+x /usr/local/bin/uid_entrypoint && \
     chgrp 0 /usr/local/bin/uid_entrypoint && \
     chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
-ENTRYPOINT [ "uid_entrypoint" ]
+ENTRYPOINT [ "uid_entrypoint", "dumb-init" ]
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
+      dumb-init \
       libgtk-3-0=3.22.* \
       tigervnc-standalone-server \
       tigervnc-common \

--- a/jenkins/pod-templates/cdt-full-pod-small.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-small.yaml
@@ -5,8 +5,7 @@ spec:
   - name: cdt
     image: quay.io/eclipse-cdt/cdt-infra-eclipse-full@sha256:88c1bcdcb29577547df7c5af80603a35fbc9edff832422e1a462573be60b3983
     tty: true
-    command: ["/bin/sh"]
-    args: ["-c", "/home/vnc/.vnc/xstartup.sh && cat"]
+    args: ["/home/vnc/.vnc/xstartup.sh", "cat"]
     resources:
       requests:
         memory: "1.75Gi"

--- a/jenkins/pod-templates/cdt-full-pod-standard.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-standard.yaml
@@ -5,8 +5,7 @@ spec:
   - name: cdt
     image: quay.io/eclipse-cdt/cdt-infra-eclipse-full@sha256:88c1bcdcb29577547df7c5af80603a35fbc9edff832422e1a462573be60b3983
     tty: true
-    command: ["/bin/sh"]
-    args: ["-c", "/home/vnc/.vnc/xstartup.sh && cat"]
+    args: ["/home/vnc/.vnc/xstartup.sh", "cat"]
     resources:
       requests:
         memory: "2.6Gi"

--- a/jenkins/pod-templates/cdt-platform-sdk.yaml
+++ b/jenkins/pod-templates/cdt-platform-sdk.yaml
@@ -5,8 +5,7 @@ spec:
   - name: platform-sdk
     image: quay.io/eclipse-cdt/cdt-infra-platform-sdk@sha256:ccc2819cfd1691cce764870002b2ba7ade8ad313281806b8260abd309b4ba8bb
     tty: true
-    command: ["/bin/sh"]
-    args: ["-c", "/home/vnc/.vnc/xstartup.sh && cat"]
+    args: ["/home/vnc/.vnc/xstartup.sh", "cat"]
     resources:
       requests:
         memory: "2.6Gi"


### PR DESCRIPTION
Also modified pod templates to let dockerfiles' entrypoint being taken
into account, but overrides args/command to start xvnc and start cat -

See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes
for details.