### PR TITLE
Skip default checkout, checkout in Git Clone stage

### DIFF
--- a/jenkins/pipelines/cdt/cdt-master.Jenkinsfile
+++ b/jenkins/pipelines/cdt/cdt-master.Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
   options {
     timestamps()
     disableConcurrentBuilds()
+    skipDefaultCheckout() // Since Git Clone exists as a stage, no benefit from a default checkout
   }
   stages {
     stage('Process info') {
@@ -24,7 +25,8 @@ pipeline {
     stage('Git Clone') {
       steps {
         container('cdt') {
-          checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 20], [$class: 'CloneOption', depth: 0, noTags: true, reference: '', shallow: false, timeout: 20]], submoduleCfg: [], userRemoteConfigs: [[url: 'git://git.eclipse.org/gitroot/cdt/org.eclipse.cdt.git']]])
+          deleteDir() // Assure a clean workspace to start the fetch
+          checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'CloneOption', noTags: true, timeout: 20]], userRemoteConfigs: [[url: 'git://git.eclipse.org/gitroot/cdt/org.eclipse.cdt.git']]])
         }
       }
     }


### PR DESCRIPTION
The default checkout is likely not helping performance, since it performs a checkout and then the `checkout scm` performs another checkout

Simplify options to checkout scm by skipping options that have a default value.

Does not set timeout value for `checkout`, just for clone. Since `checkout` is a local operation, if it is suffering from timeout, that would indicate file system  performance issues in the workspace.