### PR TITLE
Bug 563864: Mark builds as unstable when test fail

### DIFF
--- a/jenkins/pipelines/cdt/cdt-master-standalone-debugger.Jenkinsfile
+++ b/jenkins/pipelines/cdt/cdt-master-standalone-debugger.Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
             withEnv(['MAVEN_OPTS=-Xmx768m -Xms768m']) {
                 sh "/usr/share/maven/bin/mvn \
                       clean verify -B -V \
+                      -Dmaven.test.failure.ignore=true \
                       -P build-standalone-debugger-rcp \
                       -P baseline-compare-and-replace \
                       -DuseSimrelRepo \

--- a/jenkins/pipelines/cdt/cdt-master.Jenkinsfile
+++ b/jenkins/pipelines/cdt/cdt-master.Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
             withEnv(['MAVEN_OPTS=-Xmx768m -Xms768m']) {
                 sh "/usr/share/maven/bin/mvn \
                       clean verify -B -V \
+                      -Dmaven.test.failure.ignore=true \
                       -P baseline-compare-and-replace \
                       -Ddsf.gdb.tests.timeout.multiplier=50 \
                       -Dindexer.timeout=300 \

--- a/jenkins/pipelines/cdt/verify/cdt-verify-test-cdt-other-pipeline.Jenkinsfile
+++ b/jenkins/pipelines/cdt/verify/cdt-verify-test-cdt-other-pipeline.Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
             withEnv(['MAVEN_OPTS=-Xmx768m -Xms768m']) {
                 sh "/usr/share/maven/bin/mvn \
                       clean verify -B -V \
+                      -Dmaven.test.failure.ignore=true \
                       -P skip-tests-except-cdt-other \
                       -DskipDoc=true \
                       -Ddsf.gdb.tests.timeout.multiplier=50 \

--- a/jenkins/pipelines/cdt/verify/cdt-verify-test-cdt-ui-only-pipeline.Jenkinsfile
+++ b/jenkins/pipelines/cdt/verify/cdt-verify-test-cdt-ui-only-pipeline.Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
             withEnv(['MAVEN_OPTS=-Xmx768m -Xms768m']) {
                 sh "/usr/share/maven/bin/mvn \
                       clean verify -B -V \
+                      -Dmaven.test.failure.ignore=true \
                       -P skip-tests-except-cdt-ui \
                       -DskipDoc=true \
                       -Ddsf.gdb.tests.timeout.multiplier=50 \

--- a/jenkins/pipelines/cdt/verify/cdt-verify-test-dsf-gdb-only-pipeline.Jenkinsfile
+++ b/jenkins/pipelines/cdt/verify/cdt-verify-test-dsf-gdb-only-pipeline.Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
             withEnv(['MAVEN_OPTS=-Xmx768m -Xms768m']) {
                 sh "/usr/share/maven/bin/mvn \
                       clean verify -B -V \
+                      -Dmaven.test.failure.ignore=true \
                       -P skip-tests-except-dsf-gdb \
                       -DskipDoc=true \
                       -Ddsf.gdb.tests.timeout.multiplier=50 \


### PR DESCRIPTION
Now that CDT is changing the default for test failure ignore,
the CI jobs want them on.