### PR TITLE
download-build-gdb.sh: add support for GDB 9.2

### DIFF
--- a/docker/scripts/download-build-gdb.sh
+++ b/docker/scripts/download-build-gdb.sh
@@ -32,7 +32,7 @@ default_jlevel="4"
 jlevel="${default_jlevel}"
 
 # Supported versions
-default_versions="9.1 8.3.1 8.2.1 8.1.1 8.0.1 7.12.1 7.11.1 7.10.1 7.9.1 7.8.2 7.7.1 7.6.2 7.5.1 7.4.1 7.3.1 7.2 7.1 7.0.1 6.8 6.7.1 6.6"
+default_versions="9.2 8.3.1 8.2.1 8.1.1 8.0.1 7.12.1 7.11.1 7.10.1 7.9.1 7.8.2 7.7.1 7.6.2 7.5.1 7.4.1 7.3.1 7.2 7.1 7.0.1 6.8 6.7.1 6.6"
 
 # Is set to "echo" if we are doing a dry-run.
 dryrun=""


### PR DESCRIPTION
Replace GDB 9.1 with GDB 9.2.  Note that starting with GDB 9, the
numbering scheme of GDB is similar to that of GCC.  GDB 9.1 is the first
release of the 9 series, GDB 9.2 is the bugfix release on top of it.

Signed-off-by: Simon Marchi <simon.marchi@polymtl.ca>