### PR TITLE
Use node 10

### DIFF
--- a/docker/cdt-infra-eclipse-full/ubuntu-18.04/Dockerfile
+++ b/docker/cdt-infra-eclipse-full/ubuntu-18.04/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip3 install meson
 
 #Node
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*  \
     && npm install -g yarn
@@ -72,7 +72,7 @@ RUN mkdir /tmp/x \
     && find $JAVA11_HOME/include \
     && rm -rf /tmp/x
 
-# Get pre-built MacOSX toolchain from other image (this also 
+# Get pre-built MacOSX toolchain from other image (this also
 # requires clang to be listed in the installs above)
 COPY --from=cdt-infra-build-macos-sdk:ubuntu-18.04 /opt/osxcross/target /opt/osxcross/target
 ENV PATH="/opt/osxcross/target/bin:${PATH}"


### PR DESCRIPTION
Node 8 is deprecated and newer dependencies expect to run on Node 10.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

Closes https://github.com/eclipse-cdt/cdt-infra/issues/37